### PR TITLE
Fix clsx import

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import clsx, { type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {


### PR DESCRIPTION
## Summary
- fix import statement for `clsx`

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff01db170832596ac4dc473eb8a35