### PR TITLE
Add vitest browser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"typescript-eslint": "^8.20.0",
 		"vite": "^6.2.6",
 		"vite-plugin-devtools-json": "^0.1.0",
-		"vitest": "^3.0.0"
+		"vitest": "^3.0.0",
+		"@vitest/browser": "^3.0.0"
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import devtoolsJson from 'vite-plugin-devtools-json';
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit(), devtoolsJson()],
 	test: {
-		workspace: [
+		projects: [
 			{
 				extends: './vite.config.ts',
 				plugins: [svelteTesting()],
@@ -17,7 +17,12 @@ export default defineConfig({
 					clearMocks: true,
 					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 					exclude: ['src/lib/server/**'],
-					setupFiles: ['./vitest-setup-client.ts']
+					setupFiles: ['./vitest-setup-client.ts'],
+					browser: {
+						enabled: true,
+						name: 'chromium',
+						provider: 'playwright'
+					}
 				}
 			},
 			{


### PR DESCRIPTION
## Summary
- rename deprecated `workspace` to `projects` in Vitest config
- enable browser testing via Playwright in `vite.config.ts`
- add `@vitest/browser` dev dependency

## Testing
- `npm run lint` *(fails: Code style issues found in 7 files. Run Prettier with --write to fix.)*
- `npm run test:unit -- --run` *(fails: Cannot find package '@vitest/browser')*


------
https://chatgpt.com/codex/tasks/task_e_68401bfc6e688325b9f1c196f0f06643